### PR TITLE
Encoding set to UTF-8

### DIFF
--- a/check_http_load_time.rb
+++ b/check_http_load_time.rb
@@ -6,6 +6,9 @@ require 'time'
 require 'optparse'
 require 'timeout'
 
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 options = {}
 options[:url] = ""
 options[:phantomjs_bin] = "/usr/bin/phantomjs"


### PR DESCRIPTION
Changed Encoding (primary def_external, internal isn’t really needed)
from Default (Based on local System … but US-ASCII most of the Time) to
UTF-8 to get ride of an JSON.parse Error on with „German Umlaute“ in
HTML Title Tag